### PR TITLE
Update search keys

### DIFF
--- a/hs-help-guide/SearchKeyController.js
+++ b/hs-help-guide/SearchKeyController.js
@@ -2,9 +2,10 @@ function SearchKeyController(searchList) {
 this.elementList = searchList.querySelectorAll('li');
 }
 SearchKeyController.prototype.moveSelection = function(down) {
-if (!this.selectedElement) {
+if (this.selectedElement === undefined) {
 	this.selectedElement = this.elementList[0];
 	this.selectedElement.classList.add('searchKeySelected');
+console.log(this.elementList);
 	return this;
 }
 this.selectedElement.className = this.selectedElement.className.replace(/searchKeySelected/g,'');
@@ -39,6 +40,16 @@ this.selectedElement.click();
 return this;
 }
 
+SearchKeyController.prototype.undefineSelectedElement = function() {
+this.selectedElement.className = this.selectedElement.className.replace(/searchKeySelected/g,'');
+this.selectedElement = undefined;
+return this;
+}
+
 SearchKeyController.prototype.newElementList = function(list) {
 this.elementList = list;
+if (Array.from(this.elementList).indexOf(this.selectedElement) == -1) {
+	this.undefineSelectedElement();
+}
+return this;
 }

--- a/hs-help-guide/search keys.js
+++ b/hs-help-guide/search keys.js
@@ -2,12 +2,13 @@ const skc = new SearchKeyController($('#blockSearch')[0]);
 document.addEventListener('keydown',e => {
 const key = e.key;
 if (key == 'ArrowUp' || key == 'ArrowDown'){
-blockSearch(true);
+$('#blockSearchBox').focus();
 skc.moveSelection(key.length > 7)
 } else if (key == 'Escape'){
 blockSearch(false);
 $('#blockSearchBox').blur();
 } else if (key == 'Enter') {
 skc.selectCurrent();
+$('#blockSearchBox').blur();
 }
 });


### PR DESCRIPTION
Enter when searching with keys now blurs input. When you search, if the current selection is not a result it will get unselected. Opening search with arrow keys focuses the search box.